### PR TITLE
CSC-1933 Make oauth2client lib compatible with Django 2.x

### DIFF
--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,7 +14,7 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '4.1.5'
+__version__ = '4.1.6'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://oauth2.googleapis.com/device/code'

--- a/oauth2client/contrib/django_util/__init__.py
+++ b/oauth2client/contrib/django_util/__init__.py
@@ -417,7 +417,7 @@ def _credentials_from_request(request):
     """Gets the authorized credentials for this flow, if they exist."""
     # ORM storage requires a logged in user
     if (oauth2_settings.storage_model is None or
-            request.user.is_authenticated()):
+            request.user.is_authenticated):
         return get_storage(request).get()
     else:
         return None

--- a/oauth2client/contrib/django_util/decorators.py
+++ b/oauth2client/contrib/django_util/decorators.py
@@ -71,7 +71,7 @@ def oauth_required(decorated_function=None, scopes=None, **decorator_kwargs):
         @wraps(wrapped_function)
         def required_wrapper(request, *args, **kwargs):
             if not (django_util.oauth2_settings.storage_model is None or
-                    request.user.is_authenticated()):
+                    request.user.is_authenticated):
                 redirect_str = '{0}?next={1}'.format(
                     django.conf.settings.LOGIN_URL,
                     parse.quote(request.path))

--- a/oauth2client/contrib/django_util/views.py
+++ b/oauth2client/contrib/django_util/views.py
@@ -177,7 +177,7 @@ def oauth2_authorize(request):
     scopes = request.GET.getlist('scopes', django_util.oauth2_settings.scopes)
     # Model storage (but not session storage) requires a logged in user
     if django_util.oauth2_settings.storage_model:
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return redirect('{0}?next={1}'.format(
                 settings.LOGIN_URL, parse.quote(request.get_full_path())))
         # This checks for the case where we ended up here because of a logged


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
